### PR TITLE
Add go report card for jrhouston/grenade

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Grenade 💣 🔥
+# Grenade 💣 🔥 [![Go Report Card](https://goreportcard.com/badge/github.com/jrhouston/grenade)](https://goreportcard.com/report/github.com/jrhouston/grenade)
 
 ![](https://media.giphy.com/media/9PkfGzhKwBDHPTnDSj/giphy.gif)
 


### PR DESCRIPTION
Fixes #1: Add Go Report Card

Report card available at: https://goreportcard.com/report/github.com/jrhouston/grenade